### PR TITLE
venv가 정의되지 않아 에러가 남. venv를 정의하기 위해 가장 처음에 운영체제를 가려서 venv의 경로를 달리 설정하도록 bat 파일을 실행하는 명령어를 추가.

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -197,7 +197,7 @@
     <detection-done>true</detection-done>
     <sorting>DEFINITION_ORDER</sorting>
   </component>
-  <component name="ProjectFrameBounds" extendedState="7">
+  <component name="ProjectFrameBounds" extendedState="6">
     <option name="x" value="-19" />
     <option name="y" value="9" />
     <option name="width" value="1938" />
@@ -775,7 +775,7 @@
     <servers />
   </component>
   <component name="ToolWindowManager">
-    <frame x="-9" y="-9" width="1938" height="1048" extended-state="7" />
+    <frame x="-9" y="-9" width="1938" height="1048" extended-state="6" />
     <editor active="true" />
     <layout>
       <window_info id="TODO" active="false" anchor="bottom" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.33" sideWeight="0.5" order="6" side_tool="false" content_ui="tabs" />

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,8 @@ ifdef update
   u=-u
 endif
 
-#LinuxwindowsScript.bat test 
+#test
+cmd /C LinuxWindowsScript.bat
 #Windows
 #VENV ?= ..\venv\Scripts\activate.bat
 #Linux
@@ -56,7 +57,6 @@ lint:
 	flake8 src tests
 
 test:
-	cmd /C LinuxWindowsScript.bat
 	python setup.py test $(TEST_ARGS)
 
 jenkins: test


### PR DESCRIPTION
venv가 정의되지 않아 에러가 남. venv를 정의하기 위해 가장 처음에 운영체제를 가려서 venv의 경로를 달리 설정하도록 bat 파일을 실행하는 명령어를 추가.